### PR TITLE
Исправление расположения каретки

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -48,9 +48,9 @@ alias ls='ls --color=auto'
 alias ip='ip -c'
 alias reboot='sudo reboot'
 alias poweroff='sudo poweroff'
+alias tree='tree -C'
 
-#PS1='[\e[34m\$\e[0m\e[1;93m\w\e[0m]: '
-PS1='[\e[34m\$\e[0m\e[1;93m\w\e[0m]\e[32m$(git_branch)\e[0m: '
+PS1='[\[\e[34m\]\$\[\e[0m\]\[\e[1;93m\]\w\[\e[0m\]]\[\e[32m\]$(git_branch)\[\e[0m\]: '
 
 if [ -e /usr/share/terminfo/x/xterm-256color ]; then
     export TERM='xterm-256color'


### PR DESCRIPTION
Испавлена ошибка, при которой каретка в командной строке перескакивала на новую строку или оставалась на той же и стирала предыдщуие символы.  
[Решение](https://superuser.com/questions/367275/linux-coloring-bash-prompt-will-break-carriage-return)